### PR TITLE
Sending data via Kafka was implemented

### DIFF
--- a/src/main/java/com/solvd/noteservice/kafka/KfProducer.java
+++ b/src/main/java/com/solvd/noteservice/kafka/KfProducer.java
@@ -1,0 +1,9 @@
+package com.solvd.noteservice.kafka;
+
+import com.solvd.noteservice.kafka.event.NoteEvent;
+
+public interface KfProducer {
+
+    void sendMessage(NoteEvent event);
+
+}

--- a/src/main/java/com/solvd/noteservice/kafka/KfProducerImpl.java
+++ b/src/main/java/com/solvd/noteservice/kafka/KfProducerImpl.java
@@ -1,0 +1,23 @@
+package com.solvd.noteservice.kafka;
+
+import com.solvd.noteservice.kafka.event.NoteEvent;
+import com.solvd.noteservice.kafka.property.KfProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KfProducerImpl implements KfProducer{
+
+    private final KafkaTemplate<String, NoteEvent> kafkaTemplate;
+    private final KfProperties kfProperties;
+
+    @Override
+    public void sendMessage(NoteEvent event) {
+        kafkaTemplate.send(kfProperties.getTopic(), event);
+    }
+
+}

--- a/src/main/java/com/solvd/noteservice/kafka/config/KfProducerConfig.java
+++ b/src/main/java/com/solvd/noteservice/kafka/config/KfProducerConfig.java
@@ -1,0 +1,53 @@
+package com.solvd.noteservice.kafka.config;
+
+import com.solvd.noteservice.kafka.event.NoteEvent;
+import com.solvd.noteservice.kafka.property.KfProperties;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class KfProducerConfig {
+
+    private final KfProperties kfProperties;
+
+    @Bean
+    public NewTopic topic() {
+        return TopicBuilder.name(kfProperties.getTopic())
+                .partitions(kfProperties.getPartitions())
+                .replicas(kfProperties.getReplicas())
+                .build();
+    }
+
+    @Bean
+    public Map<String, Object> producerConfigs() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kfProperties.getPort());
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return config;
+    }
+
+    @Bean
+    public ProducerFactory<String, NoteEvent> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(producerConfigs());
+    }
+
+    @Bean
+    public KafkaTemplate<String, NoteEvent> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+}

--- a/src/main/java/com/solvd/noteservice/kafka/event/NoteEvent.java
+++ b/src/main/java/com/solvd/noteservice/kafka/event/NoteEvent.java
@@ -1,0 +1,23 @@
+package com.solvd.noteservice.kafka.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class NoteEvent {
+
+    private Method type;
+    private Long id;
+    private String description;
+    private String theme;
+    private String tag;
+    private Long userId;
+
+    public enum Method {
+        PUT, DELETE, POST;
+    }
+
+}

--- a/src/main/java/com/solvd/noteservice/kafka/property/KfProperties.java
+++ b/src/main/java/com/solvd/noteservice/kafka/property/KfProperties.java
@@ -1,0 +1,18 @@
+package com.solvd.noteservice.kafka.property;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@RequiredArgsConstructor
+@Getter
+@ConfigurationProperties(prefix = "kafka")
+public class KfProperties {
+
+    private final String topic;
+    private final Integer partitions;
+    private final Integer replicas;
+    private final String port;
+    private final String key;
+
+}

--- a/src/main/java/com/solvd/noteservice/service/client/ElasticClient.java
+++ b/src/main/java/com/solvd/noteservice/service/client/ElasticClient.java
@@ -1,0 +1,26 @@
+package com.solvd.noteservice.service.client;
+
+import com.solvd.noteservice.domain.Note;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+import java.util.Optional;
+
+@FeignClient(name = "esearch", url = "http://${open.feign.host}/api/v1/esearch")
+public interface ElasticClient {
+
+    @GetMapping("/{id}")
+    Optional<Note> findById(@PathVariable Long id);
+
+    @GetMapping("/users/{userId}")
+    List<Note> findAllByUserId(@PathVariable Long userId);
+
+    @GetMapping
+    List<Note> findAll();
+
+    @GetMapping("/exists/{id}")
+    boolean isExistById(@PathVariable Long id);
+
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds Kafka integration to the NoteService, allowing for event-driven architecture. It also replaces direct repository calls with Feign client calls to ElasticSearch.

### Detailed summary
- Added `KfProducer` interface and `KfProducerImpl` class for Kafka integration.
- Added `KfProperties` class for Kafka configuration.
- Added `KfProducerConfig` class for Kafka producer factory and template configuration.
- Added `NoteEvent` class for Kafka message payload.
- Replaced direct repository calls with Feign client calls to ElasticSearch in `NoteServiceImpl`.
- Added `ElasticClient` interface for Feign client calls to ElasticSearch.
- Modified `NoteServiceImpl` methods to use `ElasticClient` instead of direct repository calls.
- Added Kafka message sending to `NoteServiceImpl` methods.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->